### PR TITLE
feat(chrome-extension): rename the profile

### DIFF
--- a/apps/chrome-extension/src/entities/textPreferences/model/state/useTextPreferences.spec.ts
+++ b/apps/chrome-extension/src/entities/textPreferences/model/state/useTextPreferences.spec.ts
@@ -76,16 +76,16 @@ describe('useTextPreferences()', () => {
     })
   })
 
-  describe('updateProfileSettings()', () => {
+  describe('updateProfile()', () => {
     it('should update profile settings', () => {
-      const { preferences, setProfiles, updateProfileSettings } = useTextPreferences()
+      const { preferences, setProfiles, updateProfile } = useTextPreferences()
       const newSettings: Settings = {
         ...profile.settings,
         fontFamily: 'OpenDyslexic'
       }
       setProfiles([profile])
 
-      updateProfileSettings(profile.id, newSettings)
+      updateProfile(profile.id, { settings: newSettings })
 
       expect(preferences.profiles).toEqual([
         {
@@ -95,12 +95,27 @@ describe('useTextPreferences()', () => {
       ])
     })
 
+    it('should update profile name', () => {
+      const { preferences, setProfiles, updateProfile } = useTextPreferences()
+      const newProfileName = 'New profile name'
+      setProfiles([profile])
+
+      updateProfile(profile.id, { name: newProfileName })
+
+      expect(preferences.profiles).toEqual([
+        {
+          ...profile,
+          name: newProfileName
+        }
+      ])
+    })
+
     it('when profile id does not exist', () => {
-      const { setProfiles, updateProfileSettings } = useTextPreferences()
+      const { setProfiles, updateProfile } = useTextPreferences()
       setProfiles([profile])
 
       expect(() => {
-        updateProfileSettings(1001, profile.settings)
+        updateProfile(1001, { settings: profile.settings })
       }).toThrow(NonExistingIdError)
     })
   })

--- a/apps/chrome-extension/src/entities/textPreferences/model/state/useTextPreferences.ts
+++ b/apps/chrome-extension/src/entities/textPreferences/model/state/useTextPreferences.ts
@@ -13,7 +13,7 @@ export function useTextPreferences() {
   }
 
   const setProfiles = (profiles: TextProfile[]) => {
-    state.profiles = profiles
+    state.profiles = cloneDeep(profiles)
     if (profiles.length === 0) {
       state.activeProfileId = null
     } else if (!state.activeProfileId || !getProfileById(state.activeProfileId)) {
@@ -43,12 +43,16 @@ export function useTextPreferences() {
     return state.profiles.find(({ id }) => id === profileId)
   }
 
-  const updateProfileSettings = (profileId: TextProfileId, settings: Settings) => {
+  const updateProfile = (profileId: TextProfileId, { settings, name }: { settings?: Settings; name?: string }) => {
     const profile = getProfileById(profileId)
-    if (profile) {
-      profile.settings = settings
-    } else {
+    if (!profile) {
       throw new NonExistingIdError()
+    }
+    if (settings) {
+      profile.settings = cloneDeep(settings)
+    }
+    if (name) {
+      profile.name = name
     }
   }
 
@@ -69,7 +73,7 @@ export function useTextPreferences() {
     setProfiles,
     createProfile,
     getProfileById,
-    updateProfileSettings,
+    updateProfile,
     setActiveProfileId,
     generateNextProfileId
   }

--- a/apps/chrome-extension/src/features/textProfileRenameButton/index.ts
+++ b/apps/chrome-extension/src/features/textProfileRenameButton/index.ts
@@ -1,1 +1,1 @@
-export { default as TextProfileSaveButton } from './ui/TextProfileSaveButton.vue'
+export { default as TextProfileRenameButton } from './ui/TextProfileRenameButton.vue'

--- a/apps/chrome-extension/src/features/textProfileRenameButton/ui/TextProfileRenameButton.vue
+++ b/apps/chrome-extension/src/features/textProfileRenameButton/ui/TextProfileRenameButton.vue
@@ -1,14 +1,35 @@
 <script lang="ts" setup>
 import { useTextPreferences, TextProfileId } from '@/entities/textPreferences'
-import { Settings } from '@readapt/settings'
 import { BButton } from 'bootstrap-vue'
-import { nextTick } from 'vue'
+
+const { preferences, updateProfile, getProfileById } = useTextPreferences()
 
 const props = defineProps<{ profileId: TextProfileId | null }>()
+
+const onClick = () => {
+  const profileName = getProfileById(props.profileId)?.name
+  const newProfileName = prompt("How you'd like to name the profile?", profileName)
+  if (!newProfileName) {
+    return
+  }
+  if (isNameUnique(newProfileName)) {
+    updateProfile(props.profileId, { name: newProfileName })
+  } else {
+    alert(`A profile "${newProfileName}" already exists. Please try another name.`)
+  }
+}
+
+const isNameUnique = (newProfileName: string) => {
+  const profileWithNameExists = preferences.profiles.some(({ name, id }) => {
+    if (id === props.profileId) {
+      return false
+    }
+    return name === newProfileName
+  })
+
+  return !profileWithNameExists
+}
 </script>
 <template>
-  <b-button v-if="props.profileId" data-test-id="rename" size="sm" variant="primary">
-    <!-- {{ $t('SETTINGS.SAVE') }} -->
-    Rename
-  </b-button>
+  <span v-if="props.profileId" data-test-id="rename" @click="onClick">&#x270e;</span>
 </template>

--- a/apps/chrome-extension/src/features/textProfileSaveButton/ui/TextProfileSaveButton.spec.ts
+++ b/apps/chrome-extension/src/features/textProfileSaveButton/ui/TextProfileSaveButton.spec.ts
@@ -5,6 +5,10 @@ import { mockAlert, mockPrompt } from '@/shared/test'
 import { Settings } from '@readapt/settings'
 
 describe('TextProfileSaveButton', () => {
+  beforeEach(() => {
+    mockAlert()
+  })
+
   afterEach(() => {
     useTextPreferences().reset()
     jest.restoreAllMocks()
@@ -13,6 +17,8 @@ describe('TextProfileSaveButton', () => {
   describe('when save button is clicked', () => {
     describe('when the profile is new', () => {
       const newProfileFactory = (newProfileName = 'My Profile') => {
+        mockPrompt(newProfileName)
+
         const wrapper = mount(TextProfileSave, {
           propsData: {
             value: null,
@@ -21,10 +27,9 @@ describe('TextProfileSaveButton', () => {
         })
         const { preferences, setProfiles, setActiveProfileId } = useTextPreferences()
 
-        mockPrompt(newProfileName)
         const save = async () => await wrapper.find('[data-test-id=save]').trigger('click')
 
-        return { wrapper, preferences, setProfiles, setActiveProfileId, alert: mockAlert(), save }
+        return { wrapper, preferences, setProfiles, setActiveProfileId, save }
       }
 
       it('should create a new profile', async () => {
@@ -42,7 +47,7 @@ describe('TextProfileSaveButton', () => {
       })
 
       it('should notify about new profile creation', async () => {
-        const { save, alert } = newProfileFactory()
+        const { save } = newProfileFactory()
 
         await save()
 
@@ -104,7 +109,7 @@ describe('TextProfileSaveButton', () => {
         })
 
         it('should notify that a profile with the same name exists', async () => {
-          const { save, setProfiles, alert } = newProfileFactory(profile.name)
+          const { save, setProfiles } = newProfileFactory(profile.name)
           setProfiles([profile])
 
           await save()
@@ -133,7 +138,7 @@ describe('TextProfileSaveButton', () => {
         })
 
         it('should notify about max number of profiles', async () => {
-          const { save, alert, setProfiles } = newProfileFactory()
+          const { save, setProfiles } = newProfileFactory()
           setProfiles(profiles)
 
           await save()
@@ -161,7 +166,7 @@ describe('TextProfileSaveButton', () => {
 
         const save = async () => await wrapper.find('[data-test-id=save]').trigger('click')
 
-        return { wrapper, preferences, setProfiles, alert: mockAlert(), save }
+        return { wrapper, preferences, setProfiles, save }
       }
 
       it('should edit the profile', async () => {
@@ -179,7 +184,7 @@ describe('TextProfileSaveButton', () => {
       })
 
       it('should notify about profile update', async () => {
-        const { save, alert, setProfiles } = editProfileFactory()
+        const { save, setProfiles } = editProfileFactory()
         setProfiles([profile])
 
         await save()

--- a/apps/chrome-extension/src/features/textProfileSaveButton/ui/TextProfileSaveButton.vue
+++ b/apps/chrome-extension/src/features/textProfileSaveButton/ui/TextProfileSaveButton.vue
@@ -15,10 +15,10 @@ const emit = defineEmits<{
 
 const onClick = () => (props.value ? update() : create())
 
-const { preferences, createProfile, updateProfileSettings, setActiveProfileId } = useTextPreferences()
+const { preferences, createProfile, updateProfile } = useTextPreferences()
 
 const update = () => {
-  updateProfileSettings(props.value, props.settings)
+  updateProfile(props.value, { settings: props.settings })
   alert('The profile has been updated!')
 }
 

--- a/apps/chrome-extension/src/pages/options/ui/OptionsPage.vue
+++ b/apps/chrome-extension/src/pages/options/ui/OptionsPage.vue
@@ -9,6 +9,7 @@ import { useTextPreferences, TextProfileId } from '@/entities/textPreferences'
 import { TextProfileEditDropdown } from '@/features/textProfileEditDropdown'
 import { TextProfileSaveButton } from '@/features/textProfileSaveButton'
 import { TextAdaptationPreview } from '@/features/textAdaptationPreview'
+import { TextProfileRenameButton } from '@/features/textProfileRenameButton'
 import { useFormSettings } from '../model/useFormSettings'
 
 import SettingsMenuGeneral from '@/views/SettingsMenuGeneral.vue'
@@ -48,6 +49,7 @@ const { t } = useI18n()
       <div class="mb-2">
         <h2 class="options-page__title mr-2">Profile:</h2>
         <TextProfileEditDropdown class="options-page__profiles-dropdown" v-model="selectedProfiledId" :settings="settings" />
+        <TextProfileRenameButton class="options-page__profile-rename ml-3" :profile-id="selectedProfiledId" />
         <TextSettingsFileDownload class="ml-2 float-right" :settings="settings" />
       </div>
       <b-nav class="d-flex flex-row">
@@ -112,6 +114,12 @@ const { t } = useI18n()
   &__profiles-dropdown {
     font-size: 24px;
     width: 250px;
+  }
+
+  &__profile-rename {
+    font-weight: bold;
+    font-size: 32px;
+    cursor: pointer;
   }
 }
 .nav-item {

--- a/apps/chrome-extension/src/shared/test.ts
+++ b/apps/chrome-extension/src/shared/test.ts
@@ -1,4 +1,4 @@
-export const mockPrompt = (result: string) => {
+export const mockPrompt = (result: string | null) => {
   return jest.spyOn(window, 'prompt').mockReset().mockReturnValueOnce(result)
 }
 


### PR DESCRIPTION
This PR introduces the possibility to rename a profile in the options page.

## UI Changes

### Before

<img width="1510" alt="Screenshot 2022-12-06 at 09 15 19" src="https://user-images.githubusercontent.com/1078719/205856934-c46b637e-906f-4c83-bf12-1304421feb9e.png">

### After 

https://user-images.githubusercontent.com/1078719/205856973-bf500301-affa-4a48-8191-f33cf66d4297.mov

