### PR TITLE
feat: release version 1.6.1

### DIFF
--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -14,10 +14,10 @@
     "postinstall": "node scripts/init-env"
   },
   "dependencies": {
-    "@readapt/settings": "^1.6.1-alpha.1",
-    "@readapt/shared-components": "^1.6.1-alpha.1",
-    "@readapt/text-engine": "^1.6.1-alpha.1",
-    "@readapt/visual-engine": "^1.6.1-alpha.1",
+    "@readapt/settings": "^1.6.1",
+    "@readapt/shared-components": "^1.6.1",
+    "@readapt/text-engine": "^1.6.1",
+    "@readapt/visual-engine": "^1.6.1",
     "bootstrap": "~4.6.1",
     "bootstrap-vue": "~2.22.0",
     "core-js": "^3.8.3",

--- a/apps/ms-word-addin/package.json
+++ b/apps/ms-word-addin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-word-addin",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -19,10 +19,10 @@
     "postinstall": "node scripts/init-env"
   },
   "dependencies": {
-    "@readapt/settings": "^1.6.1-alpha.1",
-    "@readapt/shared-components": "^1.6.1-alpha.1",
-    "@readapt/text-engine": "^1.6.1-alpha.1",
-    "@readapt/visual-engine": "^1.6.1-alpha.1",
+    "@readapt/settings": "^1.6.1",
+    "@readapt/shared-components": "^1.6.1",
+    "@readapt/text-engine": "^1.6.1",
+    "@readapt/visual-engine": "^1.6.1",
     "bootstrap": "~4.6.1",
     "bootstrap-vue": "~2.22.0",
     "core-js": "^3.8.3",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/dictionaries/package.json
+++ b/packages/dictionaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readapt/dictionaries",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "types": "dist/index.d.ts",
   "main": "",
   "targets": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readapt/settings",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "main": "dist/readapt-settings.js",
   "module": "dist/readapt-settings.esm.js",
   "types": "dist/types/index.d.ts",

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readapt/shared-components",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "main": "dist/readapt-shared-components.common.js",
   "module": "dist/readapt-shared-components.common.js",
   "types": "dist/types.d.ts",
@@ -26,8 +26,8 @@
     "url": "git+https://github.com/ContentSquare/readapt.git"
   },
   "dependencies": {
-    "@readapt/settings": "^1.6.1-alpha.1",
-    "@readapt/visual-engine": "^1.6.1-alpha.1",
+    "@readapt/settings": "^1.6.1",
+    "@readapt/visual-engine": "^1.6.1",
     "bootstrap": "~4.6.1",
     "bootstrap-vue": "~2.22.0",
     "core-js": "^3.8.3"

--- a/packages/text-engine/package.json
+++ b/packages/text-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readapt/text-engine",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "main": "dist/readapt-text-engine.js",
   "module": "dist/readapt-text-engine.esm.js",
   "types": "dist/index.d.ts",
@@ -25,6 +25,6 @@
     "src/*"
   ],
   "dependencies": {
-    "@readapt/dictionaries": "^1.6.1-alpha.1"
+    "@readapt/dictionaries": "^1.6.1"
   }
 }

--- a/packages/visual-engine/package.json
+++ b/packages/visual-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readapt/visual-engine",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "main": "dist/readapt-visual-engine.js",
   "module": "dist/readapt-visual-engine.esm.js",
   "types": "dist/types/visual-engine/src/index.d.ts",
@@ -22,8 +22,8 @@
     "src/*"
   ],
   "dependencies": {
-    "@readapt/settings": "^1.6.1-alpha.1",
-    "@readapt/text-engine": "^1.6.1-alpha.1",
+    "@readapt/settings": "^1.6.1",
+    "@readapt/text-engine": "^1.6.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR creates a v1.6.1 release to fix the chrome extension build (which accepts versions strictly `x.x.x` and does not accept `alpha` suffixes).