### PR TITLE
style(chrome-extension): bigger preview width on small screens

### DIFF
--- a/apps/chrome-extension/src/features/textProfileForm/ui/TextProfileFormGeneralTab.vue
+++ b/apps/chrome-extension/src/features/textProfileForm/ui/TextProfileFormGeneralTab.vue
@@ -163,7 +163,12 @@ watch(
             </div>
           </td>
           <td>
-            <RangeBar :value="settings.syllableOpacity" :options="opacityOptions" @input="emitUpdate({ key: 'syllableOpacity', value: $event })" />
+            <RangeBar
+              class="w-28 lg:w-52"
+              :value="settings.syllableOpacity"
+              :options="opacityOptions"
+              @input="emitUpdate({ key: 'syllableOpacity', value: $event })"
+            />
           </td>
           <td>
             <input type="checkbox" class="toggle" :checked="settings.syllableActive" @input="emitUpdateToggled({ key: 'syllableActive' })" />
@@ -174,7 +179,7 @@ watch(
           <td />
           <td>
             <RangeBar
-              class="w-52"
+              class="w-28 lg:w-52"
               :disabled="settings.language === 'en'"
               :value="settings.liaisonsOpacity"
               :options="opacityOptions"
@@ -190,7 +195,7 @@ watch(
           <td />
           <td>
             <RangeBar
-              class="w-52"
+              class="w-28 lg:w-52"
               :value="settings.silentLetterOpacity"
               :options="silentLetterOpacityOptions"
               @input="emitUpdate({ key: 'silentLetterOpacity', value: $event })"
@@ -206,7 +211,7 @@ watch(
           <td />
           <td>
             <RangeBar
-              class="w-52"
+              class="w-28 lg:w-52"
               :value="settings.shadeAlternateLinesOpacity"
               :options="opacityOptions"
               @input="emitUpdate({ key: 'shadeAlternateLinesOpacity', value: $event })"

--- a/apps/chrome-extension/src/pages/options/ui/OptionsPage.vue
+++ b/apps/chrome-extension/src/pages/options/ui/OptionsPage.vue
@@ -44,7 +44,7 @@ const { t } = useI18n()
       <TextSettingsFileDownload class="ml-auto" :settings="settings" />
     </div>
     <div class="flex">
-      <TextProfileForm class="w-2/3 min-w-[850px]" :settings="settings" @update-settings="updateSettings" @change-language="changeLanguage" />
+      <TextProfileForm class="w-2/3 min-w-[730px]" :settings="settings" @update-settings="updateSettings" @change-language="changeLanguage" />
       <div class="flex w-1/3 flex-1 flex-col pl-4 pt-10">
         <div class="text-2xl font-semibold">{{ $t('SETTINGS.TEXT_PREVIEW') }}</div>
         <TextSettingsAdaptationPreview class="h-items-settings overflow-scroll" :settings="settings" />


### PR DESCRIPTION
This PR gives the preview section in the options page more width when displayed on small screens.

## UI Changes

|Before|After|
|----|------|
|<img width="1120" alt="Screenshot 2023-01-27 at 18 08 00" src="https://user-images.githubusercontent.com/1078719/215150552-2ec88175-68b2-4f82-a74d-28780e4a5a7a.png">|<img width="1117" alt="Screenshot 2023-01-27 at 18 06 30" src="https://user-images.githubusercontent.com/1078719/215150559-ee134d8c-9d66-46fc-95e0-6f1a541bbd67.png">|
