### PR TITLE
feat(ms-word-addin): do not send user agent and client hints

### DIFF
--- a/apps/ms-word-addin/src/services/stats.ts
+++ b/apps/ms-word-addin/src/services/stats.ts
@@ -1,12 +1,10 @@
 import { config } from '@/constants/config'
 
 const trackAdaptEvent = (isSelection: boolean) => {
-  const url = `${config.matomoURL}/.php?idsite=2&action_name=adaptSelection&rec=1&ua=unknown&uadata={}`
-  if (isSelection) {
-    fetch(`${url}&action_name=adaptSelection`).catch(console.error)
-  } else {
-    fetch(`${url}&action_name=adaptDocument`).catch(console.error)
-  }
+  let url = `${config.matomoURL}/.php?idsite=2&action_name=adaptSelection&rec=1&ua=unknown&uadata={}`
+  url += isSelection ? '&action_name=adaptSelection' : '&action_name=adaptDocument'
+
+  fetch(url).catch(console.error)
 }
 
 export { trackAdaptEvent }

--- a/apps/ms-word-addin/src/services/stats.ts
+++ b/apps/ms-word-addin/src/services/stats.ts
@@ -1,10 +1,11 @@
 import { config } from '@/constants/config'
 
 const trackAdaptEvent = (isSelection: boolean) => {
+  const url = `${config.matomoURL}/.php?idsite=2&action_name=adaptSelection&rec=1&ua=unknown&uadata={}`
   if (isSelection) {
-    fetch(`${config.matomoURL}/matomo.php?idsite=2&action_name=adaptSelection&rec=1`).catch(console.error)
+    fetch(`${url}&action_name=adaptSelection`).catch(console.error)
   } else {
-    fetch(`${config.matomoURL}/matomo.php?idsite=2&action_name=adaptDocument&rec=1`).catch(console.error)
+    fetch(`${url}&action_name=adaptDocument`).catch(console.error)
   }
 }
 


### PR DESCRIPTION
In the MS Word Addin, do not send the browser specific information when registering a user action in Matomo.