### PR TITLE
fix(ms-word-addin): allow cors for matomo

### DIFF
--- a/apps/ms-word-addin/src/services/stats.ts
+++ b/apps/ms-word-addin/src/services/stats.ts
@@ -4,7 +4,7 @@ const trackAdaptEvent = (isSelection: boolean) => {
   let url = `${config.matomoURL}/.php?idsite=2&action_name=adaptSelection&rec=1&ua=unknown&uadata={}`
   url += isSelection ? '&action_name=adaptSelection' : '&action_name=adaptDocument'
 
-  fetch(url).catch(console.error)
+  fetch(url, { mode: 'cors' }).catch(console.error)
 }
 
 export { trackAdaptEvent }


### PR DESCRIPTION
Allow CORS requests to Matomo in MS Word Addin.