### PR TITLE
feat(chrome-extension): do not send ua and client hints to matomo

### DIFF
--- a/apps/chrome-extension/src/app/background/index.ts
+++ b/apps/chrome-extension/src/app/background/index.ts
@@ -109,7 +109,7 @@ chrome.storage.onChanged.addListener(async (changes) => {
   }
 
   if (hasEventChanged(changes)) {
-    await fetch(`${__MATOMO_URL__}/matomo.php?idsite=1&action_name=adapt&rec=1`)
+    await fetch(`${__MATOMO_URL__}/matomo.php?idsite=1&action_name=adapt&rec=1&ua=unknown&uadata={}`)
   }
 })
 


### PR DESCRIPTION
Do not send the browser info and the client hints to matomo in the chrome extension. This change reduces the accuracy of the matomo fingerprint detection from browser.