### PR TITLE
feat: add keyboard shortcuts to browser extension for ruler and mask

### DIFF
--- a/apps/browser-extension-template/src/app/contentScript/index.ts
+++ b/apps/browser-extension-template/src/app/contentScript/index.ts
@@ -299,6 +299,39 @@ document.addEventListener('keydown', (event) => {
     ReadingToolsMask.remove()
   }
 })
+// keyboard shortcuts for reading tools
+const map = { r: false, n: false, Control: false, Meta: false, Alt: false }
+document.addEventListener('keydown', (event) => {
+  if (event.key in map) {
+    ;(map as { [key: string]: boolean })[event.key] = true
+    if ((map['Control'] || map['Meta']) && map['Alt']) {
+      if (map['r']) {
+        if (ReadingToolsRuler.state.enabled) {
+          ReadingToolsRuler.remove()
+        } else {
+          if (ReadingToolsMask.state.enabled) {
+            ReadingToolsMask.remove()
+          }
+          ReadingToolsRuler.add()
+        }
+      } else if (map['n']) {
+        if (ReadingToolsMask.state.enabled) {
+          ReadingToolsMask.remove()
+        } else {
+          if (ReadingToolsRuler.state.enabled) {
+            ReadingToolsRuler.remove()
+          }
+          ReadingToolsMask.add()
+        }
+      }
+    }
+  }
+})
+document.addEventListener('keyup', (event) => {
+  if (event.key in map) {
+    ;(map as { [key: string]: boolean })[event.key] = false
+  }
+})
 // end reading tools
 
 // get extension state


### PR DESCRIPTION
Added keyboard shortcuts that activate/deactivate the mask and ruler on browser extensions as requested in #44. 

The shortcuts are:
Ruler: CTRL+ALT+R
Mask: CTRL+ALT+N (not m because of a conflict)

I have tested the functionality on Chrome and Firefox and it works as expected. I do not own a Mac to test Safari. 
All tests pass locally and in GitHub Actions. I did not contribute to any linter warnings. 
