### PR TITLE
chore migrate gihub actions to Action Manager

### DIFF
--- a/.github/actions/cache-build/action.yaml
+++ b/.github/actions/cache-build/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Cache Build
-      uses: actions/cache@v3
+      uses: ContentSquare/actions-cache@approved-v3
       with:
         path: |
           **/dist

--- a/.github/actions/cache-dependencies/action.yaml
+++ b/.github/actions/cache-dependencies/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Cache Dependencies
-      uses: actions/cache@v3
+      uses: ContentSquare/actions-cache@approved-v3
       with:
         path: |
           **/node_modules

--- a/.github/actions/cache-packages/action.yaml
+++ b/.github/actions/cache-packages/action.yaml
@@ -5,19 +5,19 @@ runs:
   using: composite
   steps:
     - name: Cache Packages Chrome
-      uses: actions/cache@v3
+      uses: ContentSquare/actions-cache@approved-v3
       with:
         path: ./apps/chrome-extension/dist/readapt-chrome-extension.zip
         key: cache-packages-chrome-${{ github.sha }}
 
     - name: Cache Packages Safari
-      uses: actions/cache@v3
+      uses: ContentSquare/actions-cache@approved-v3
       with:
         path: ./apps/safari-extension/dist/archive
         key: cache-packages-safari-${{ github.sha }}
 
     - name: Cache Packages Firefox
-      uses: actions/cache@v3
+      uses: ContentSquare/actions-cache@approved-v3
       with:
         path: ./apps/firefox-addin/dist/readapt-firefox-addin.zip
         key: cache-packages-firefox-${{ github.sha }}

--- a/.github/actions/deploy-npm/action.yaml
+++ b/.github/actions/deploy-npm/action.yaml
@@ -13,27 +13,27 @@ runs:
 
     - uses: ./.github/actions/cache-build
 
-    - uses: JS-DevTools/npm-publish@v2
+    - uses: ContentSquare/JS-DevTools-npm-publish@approved-v2
       with:
         token: ${{ inputs.npm_token }}
         package: ./packages/dictionaries/package.json
 
-    - uses: JS-DevTools/npm-publish@v2
+    - uses: ContentSquare/JS-DevTools-npm-publish@approved-v2
       with:
         token: ${{ inputs.npm_token }}
         package: ./packages/settings/package.json
 
-    - uses: JS-DevTools/npm-publish@v2
+    - uses: ContentSquare/JS-DevTools-npm-publish@approved-v2
       with:
         token: ${{ inputs.npm_token }}
         package: ./packages/shared-components/package.json
 
-    - uses: JS-DevTools/npm-publish@v2
+    - uses: ContentSquare/JS-DevTools-npm-publish@approved-v2
       with:
         token: ${{ inputs.npm_token }}
         package: ./packages/text-engine/package.json
 
-    - uses: JS-DevTools/npm-publish@v2
+    - uses: ContentSquare/JS-DevTools-npm-publish@approved-v2
       with:
         token: ${{ inputs.npm_token }}
         package: ./packages/visual-engine/package.json

--- a/.github/actions/deploy-safari/action.yaml
+++ b/.github/actions/deploy-safari/action.yaml
@@ -20,7 +20,7 @@ runs:
     - uses: ./.github/actions/cache-packages
 
     - name: 'Upload app to TestFlight'
-      uses: apple-actions/upload-testflight-build@v1
+      uses: ContentSquare/apple-actions-upload-testflight-build@approved-v1
       with:
         app-path: ./apps/safari-extension/dist/archive/Readapt.pkg
         app-type: macos

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ description: Checkout and setup node
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: ContentSquare/actions-setup-node@approved-v3
       with:
         node-version: 16.x
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,21 +10,21 @@ jobs:
   bootstrap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/bootstrap
 
   lint:
     needs: bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/lint
 
   build:
     needs: bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/build
         with:
           version: prerelease
@@ -34,5 +34,5 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,21 +11,21 @@ jobs:
   bootstrap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/bootstrap
 
   lint:
     needs: bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/lint
 
   build:
     needs: bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/build
         with:
           version: ${{ inputs.version }}
@@ -35,24 +35,24 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/test
 
   package-chrome:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/package-chrome
 
   package-safari:
     needs: [lint, test]
     runs-on: macos-13
     steps:
-      - uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+      - uses: ContentSquare/maxim-lobanov-setup-xcode@approved-9a697e2b393340c3cacd97468baa318e4c883d98
         with:
           xcode-version: '14.3'
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
 
       - name: Install the Apple certificate and provisioning profile
         env:
@@ -97,14 +97,14 @@ jobs:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/package-firefox
 
   deploy-npm:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/deploy-npm
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}
@@ -113,17 +113,17 @@ jobs:
     needs: [package-chrome]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/deploy-chrome
 
   deploy-safari:
     needs: [package-safari]
     runs-on: macos-13
     steps:
-      - uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+      - uses: ContentSquare/maxim-lobanov-setup-xcode@approved-9a697e2b393340c3cacd97468baa318e4c883d98
         with:
           xcode-version: '14.3'
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
 
       - uses: ./.github/actions/deploy-safari
         with:
@@ -135,14 +135,14 @@ jobs:
     needs: [package-firefox]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/deploy-firefox
 
   release:
     needs: [deploy-chrome, deploy-safari, deploy-firefox, deploy-npm]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ContentSquare/actions-checkout@approved-v3
       - uses: ./.github/actions/release
         with:
           version: ${{ inputs.version }}


### PR DESCRIPTION
# Description

Migrate all GitHub Actions workflow files across ContentSquare repositories to use the Actions Manager Fork-and-Approved-Tag security model.

All direct upstream action references (e.g. `actions/checkout@v4`) have been replaced with their ContentSquare-managed fork equivalents (e.g. `ContentSquare/actions-checkout@approved-v4`) using `platform_github/allowed-actions.yaml` as the source of truth.

## Motivation and Context

The [Actions Manager](https://github.com/ContentSquare/platform_github?tab=readme-ov-file#actions-manager-recommended) implements a Fork-and-Approved-Tag security model to prevent supply chain attacks. Using direct upstream action references bypasses this model and will be blocked by security controls in the future.

This change ensures all workflows use only ContentSquare-controlled forks with security-reviewed approved tags, providing:
- **Supply chain protection**: only ContentSquare-controlled forks are used
- **Approved tags only**: no raw upstream tags
- **Audit trail**: complete approval and usage history

## Breaking Changes

No breaking changes. The ContentSquare fork actions are functionally identical to their upstream counterparts — only the reference syntax changes.

Actions not present in `allowed-actions.yaml` (no approved fork available yet) were left unchanged.

## How Has This Been Tested?

See the following CI runs in this PR